### PR TITLE
✨feat: Quantização

### DIFF
--- a/codec.c
+++ b/codec.c
@@ -9,8 +9,14 @@
 
 // Clamp usado para fazer o padding se acessar um pixel fora da imagem
 // Se o pixel estiver fora da imagem, retorna o pixel da borda
-int clamp(int val, int max) {
+int padding_clamp(int val, int max) {
     return (val < max) ? val : max - 1;
+}
+
+float clamp(float value, float min, float max) {
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
 }
 
 void extract_block_y(PIXELYCBCR *image, float block[8][8], int start_x, int start_y, int width, int height) {
@@ -25,8 +31,8 @@ void extract_block_y(PIXELYCBCR *image, float block[8][8], int start_x, int star
      */
     for (int y = 0; y < 8; y++) {
         for (int x = 0; x < 8; x++) {
-            int px = clamp(start_x + x, width);
-            int py = clamp(start_y + y, height);
+            int px = padding_clamp(start_x + x, width);
+            int py = padding_clamp(start_y + y, height);
             int index = py * width + px;
             block[y][x] = (float)image[index].Y;
         }
@@ -50,8 +56,8 @@ void extract_block_chroma420(PIXELYCBCR *image, float block[8][8], int start_x, 
             float sum = 0;
             for (int dy = 0; dy < 2; dy++) {
                 for (int dx = 0; dx < 2; dx++) {
-                    int px = clamp(start_x + x * 2 + dx, width);
-                    int py = clamp(start_y + y * 2 + dy, height);
+                    int px = padding_clamp(start_x + x * 2 + dx, width);
+                    int py = padding_clamp(start_y + y * 2 + dy, height);
                     int index = py * width + px;
                     sum += (channel == 'B') ? image[index].Cb : image[index].Cr;
                 }
@@ -73,9 +79,10 @@ void reconstructBlock8x8_Y(PIXELYCBCR *dst, float block[8][8], int start_x, int 
      */
     for (int y = 0; y < 8; y++)
         for (int x = 0; x < 8; x++) {
-            int px = clamp(start_x + x, width);
-            int py = clamp(start_y + y, height);
-            dst[py * width + px].Y = (unsigned char)(block[y][x] + 0.5f);
+            int px = padding_clamp(start_x + x, width);
+            int py = padding_clamp(start_y + y, height);
+            // utiliza-se clamping para evitar overflow
+            dst[py * width + px].Y = (unsigned char)(clamp(block[y][x] + 0.5f, 0.0f, 255.0f));
         }
 }
 
@@ -92,9 +99,10 @@ void reconstructBlock8x8_CbCr420(PIXELYCBCR *dst, float block[8][8], int start_x
      */
     for (int y = 0; y < 16; y++) {
         for (int x = 0; x < 16; x++) {
-            int px = clamp(start_x + x, width);
-            int py = clamp(start_y + y, height);
-            unsigned char val = (unsigned char)(block[y / 2][x / 2] + 0.5f);
+            int px = padding_clamp(start_x + x, width);
+            int py = padding_clamp(start_y + y, height);
+            // utiliza-se clamping para evitar overflow
+            unsigned char val = (unsigned char)(clamp(block[y / 2][x / 2] + 0.5f, 0.0f, 255.0f));
             PIXELYCBCR *pix = &dst[py * width + px];
             if (channel == 'B') pix->Cb = val;
             else pix->Cr = val;
@@ -153,6 +161,121 @@ MACROBLOCO* encodeImageYCbCr(PIXELYCBCR *image, int width, int height, int *out_
     }
 
     return macroblocks;
+}
+
+float quantization_matrix_y[8][8] = {
+    {16, 11, 10, 16, 24, 40, 51, 61},
+    {12, 12, 14, 19, 26, 58, 60, 55},
+    {14, 13, 16, 24, 40, 57, 69, 56},
+    {14, 17, 22, 29, 51, 87, 80, 62},
+    {18, 22, 37, 56, 68,109,103,77},
+    {24,35,55,64,81,104,113,92},
+    {79,64,78,87,103,121,120,101},
+    {72,92 ,95 ,98 ,112 ,100 ,103 ,99}
+};
+
+float quantization_matrix_chroma[8][8] = {
+    {17, 18, 24, 47, 99, 99, 99, 99},
+    {18, 21, 26, 66, 99, 99, 99, 99},
+    {24, 26, 56, 99, 99, 99, 99, 99},
+    {47, 66, 99, 99, 99, 99, 99, 99},
+    {99, 99, 99, 99, 99, 99, 99, 99},
+    {99, 99, 99, 99, 99, 99, 99, 99},
+    {99, 99 ,99 ,99 ,99 ,99 ,99 ,99},
+    {99 ,99 ,99 ,99 ,99 ,99 ,99 ,98}
+};
+
+void quantizeBlock(float block[8][8], float quantization_matrix[8][8], int compression_factor) {
+    /*
+     * Aplica a quantização em um bloco 8x8 usando uma matriz de quantização.
+     *
+     * Parâmetros:
+     * block: bloco 8x8 a ser quantizado
+     * quantization_matrix: matriz de quantização
+     * compression_factor: fator de compressão
+     */
+    for (int y = 0; y < 8; y++) {
+        for (int x = 0; x < 8; x++) {
+            // Aplica a quantização
+            block[y][x] = round(block[y][x] / (quantization_matrix[y][x] * compression_factor));
+        }
+    }
+}
+
+void dequantizeBlock(float block[8][8], float quantization_matrix[8][8], int compression_factor) {
+    /*
+     * Aplica a dequantização em um bloco 8x8 usando uma matriz de quantização.
+     *
+     * Parâmetros:
+     * block: bloco 8x8 a ser dequantizado
+     * quantization_matrix: matriz de quantização
+     * compression_factor: fator de compressão
+     */
+    for (int y = 0; y < 8; y++) {
+        for (int x = 0; x < 8; x++) {
+            // Aplica a dequantização
+            block[y][x] *= (quantization_matrix[y][x] * compression_factor);
+        }
+    }
+}
+
+void quantizeMacroblock(MACROBLOCO *mb, int compression_factor) {
+    /*
+     * Aplica a quantização em um macrobloco 16x16.
+     *
+     * Parâmetros:
+     * mb: macrobloco a ser quantizado
+     * quantization_matrix: matriz de quantização
+     * compression_factor: fator de compressão
+     */
+    for (int i = 0; i < 4; i++) {
+        quantizeBlock(mb->Y[i].Y, quantization_matrix_y, compression_factor);
+    }
+    quantizeBlock(mb->Cb.C, quantization_matrix_chroma, compression_factor);
+    quantizeBlock(mb->Cr.C, quantization_matrix_chroma, compression_factor);
+}
+
+void dequantizeMacroblock(MACROBLOCO *mb, int compression_factor) {
+    /*
+     * Aplica a dequantização em um macrobloco 16x16.
+     *
+     * Parâmetros:
+     * mb: macrobloco a ser dequantizado
+     * quantization_matrix: matriz de quantização
+     * compression_factor: fator de compressão
+     */
+    for (int i = 0; i < 4; i++) {
+        dequantizeBlock(mb->Y[i].Y, quantization_matrix_y, compression_factor);
+    }
+    dequantizeBlock(mb->Cb.C, quantization_matrix_chroma, compression_factor);
+    dequantizeBlock(mb->Cr.C, quantization_matrix_chroma, compression_factor);
+}
+
+void quantizeMacroblocks(MACROBLOCO *mb_array, int macroblock_count, int compression_factor) {
+    /*
+     * Aplica a quantização em um vetor de macroblocos.
+     *
+     * Parâmetros:
+     * mb_array: vetor de macroblocos
+     * macroblock_count: número de macroblocos
+     * compression_factor: fator de compressão
+     */
+    for (int i = 0; i < macroblock_count; i++) {
+        quantizeMacroblock(&mb_array[i], compression_factor);
+    }
+}
+void dequantizeMacroblocks(MACROBLOCO *mb_array, int macroblock_count, int compression_factor) {
+    /*
+     * Aplica a dequantização em um vetor de macroblocos.
+     *
+     * Parâmetros:
+     * mb_array: vetor de macroblocos
+     * macroblock_count: número de macroblocos
+     * compression_factor: fator de compressão
+     */
+    for (int i = 0; i < macroblock_count; i++) {
+        dequantizeMacroblock(&mb_array[i], compression_factor);
+    }
 }
 
 void decodeImageYCbCr(MACROBLOCO *mb_array, PIXELYCBCR *dst, int width, int height) {

--- a/codec.h
+++ b/codec.h
@@ -27,5 +27,7 @@
     void extract_block_chroma420(PIXELYCBCR *image, float block[8][8], int start_x, int start_y, int width, int height, char channel);
     void reconstructBlock8x8_Y(PIXELYCBCR *dst, float block[8][8], int start_x, int start_y, int width, int height);
     void reconstructBlock8x8_CbCr420(PIXELYCBCR *dst, float block[8][8], int start_x, int start_y, int width, int height, char channel);
+    void quantizeMacroblocks(MACROBLOCO *mb_array, int macroblock_count, int compression_factor);
+    void dequantizeMacroblocks(MACROBLOCO *mb_array, int macroblock_count, int compression_factor);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -8,6 +8,8 @@
 
 int main(void) {
     /* COMPRESSÃO */
+    float factor = 1.0f; // Fator de compressão
+
     // 1. Abre o arquivo BMP de entrada
     FILE *input = fopen("images/cameraman.bmp", "rb");
     if (!input) {
@@ -45,15 +47,21 @@ int main(void) {
     MACROBLOCO *blocks = encodeImageYCbCr(PixelsYCbCr, width, height, &macroblock_count);
     printf("Number of macroblocks: %d\n", macroblock_count);
 
+    // 7. Aplica a quantização nos macroblocos
+    quantizeMacroblocks(blocks, macroblock_count, factor);
+
     /* DESCOMPRESSÃO */
-    // 1. Gera a imagem YCbCr a partir dos macroblocos
+    // 1. Aplica a dequantização nos macroblocos
+    dequantizeMacroblocks(blocks, macroblock_count, factor);
+
+    // 2. Gera a imagem YCbCr a partir dos macroblocos
     PIXELYCBCR *DecodedYCbCr = (PIXELYCBCR *) malloc(tam * sizeof(PIXELYCBCR));
     decodeImageYCbCr(blocks, DecodedYCbCr, width, height);
 
-    // 2. Converte os pixels de YCbCr para RGB
+    // 3. Converte os pixels de YCbCr para RGB
     convertToRGB(DecodedYCbCr, PixelsOut, tam);
 
-    // 3. Abre e escreve o arquivo BMP de saída
+    // 4. Abre e escreve o arquivo BMP de saída
     FILE *output = fopen("out.bmp", "wb");
     if (!output) {
         printf("Error: could not open output file.\n");


### PR DESCRIPTION
- Aplicada quantização nos macroblocos gerados pela DCT. Utilizam as matrizes abaixo.
- Aplicada dequantização pré-IDCT. Foi necessário dar **clamp** nos valores da IDCT (entre 0 e 255).

![image](https://github.com/user-attachments/assets/f3f06024-a949-405d-8f91-20ddf8649036)

Mesmo com o fator de compressão 1 a blocagem é bem perceptível. Acredito que seja o esperado já que é uma compressão com perdas. Fatores mais altos dão resultados condizentes com a compressão jpeg.

closes #12 